### PR TITLE
Docker Zig 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ zig-out
 node-modules
 .vscode
 web/scripts/js.bindings.js
+!build-game.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu
+
+ARG USER_ID
+ARG GROUP_ID
+
+RUN DEBIAN_FRONTEND=noninteractive
+RUN apt-get update &&                                              \
+    apt-get install -y --allow-downgrades --allow-remove-essential \
+        --allow-change-held-packages                               \
+        wget                                                       \
+        curl                                                       \
+        build-essential                                            \
+    && apt-get clean
+
+RUN addgroup --gid $GROUP_ID user
+RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
+
+RUN mkdir /toolchain
+RUN chown -R $USER_ID:$GROUP_ID /toolchain
+
+USER user
+
+WORKDIR /toolchain
+RUN echo "Fetching toolchain: zig-linux-x86_64-0.11.0"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://ziglang.org/download/0.11.0/zig-linux-x86_64-0.11.0.tar.xz | tar -Jxf -
+ENV PATH ${PATH}:/toolchain/zig-linux-x86_64-0.11.0
+
+# RUN chown ${USER}:${USER} -R /toolchain
+RUN chmod +x /toolchain/zig-linux-x86_64-0.11.0/zig
+
+VOLUME /game
+WORKDIR /game
+
+CMD ["zig", "build"]

--- a/build-game.sh
+++ b/build-game.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+
+ZIG_CONTAINER="uwnh-remake-zig"
+
+if test "$1" = "--help" ; then
+    echo "$0 [options]"
+    echo "   options: ['--help'    | '-h' : Print this help message.                        ]"
+    echo "            ['--verbose' | '-v' : Provide verbose output e.g: docker build output.]"
+    exit 0
+fi
+
+if test "$1" = "--verbose" ; then
+    docker build  -t "$ZIG_CONTAINER" --build-arg GROUP_ID="$(id -g)" --build-arg USER_ID="$(id -u)" .
+else
+    echo "Building a docker image, please wait it may take some time..."
+    docker build -t "$ZIG_CONTAINER" --build-arg GROUP_ID="$(id -g)" --build-arg USER_ID="$(id -u)" . >/dev/null
+fi
+
+docker run                                    \
+    --mount "type=bind,src=$(pwd)/,dst=/game" \
+    --workdir "/game"                         \
+    "$ZIG_CONTAINER"

--- a/build-game.sh
+++ b/build-game.sh
@@ -2,21 +2,38 @@
 
 ZIG_CONTAINER="uwnh-remake-zig"
 
-if test "$1" = "--help" ; then
-    echo "$0 [options]"
-    echo "   options: ['--help'    | '-h' : Print this help message.                        ]"
-    echo "            ['--verbose' | '-v' : Provide verbose output e.g: docker build output.]"
+if test "$1" = "--help" -o "$1" = "-h" ; then
+    echo "$0 [options] [-- <zig_command>]"
+    echo "   options: ['--help'    | '-h' : Print this help message.                              ]"
+    echo "            ['--silent'  | '-s' : Suppress all output except for the container its self.]"
+    echo "            ['--verbose' | '-v' : Provide verbose output e.g: docker build output.      ]"
+    echo "   <zig_command> : Execute command custom command in the Zig container e.g 'zig build-lib -rdynamic'"
     exit 0
 fi
 
-if test "$1" = "--verbose" ; then
-    docker build  -t "$ZIG_CONTAINER" --build-arg GROUP_ID="$(id -g)" --build-arg USER_ID="$(id -u)" .
+if test "$1" = "--verbose" -o "$1" = "-v" ; then
+    docker build  -t "$ZIG_CONTAINER"   \
+        --build-arg GROUP_ID="$(id -g)" \
+        --build-arg USER_ID="$(id -u)" .
 else
     echo "Building a docker image, please wait it may take some time..."
-    docker build -t "$ZIG_CONTAINER" --build-arg GROUP_ID="$(id -g)" --build-arg USER_ID="$(id -u)" . >/dev/null
+    docker build -t "$ZIG_CONTAINER"    \
+        --build-arg GROUP_ID="$(id -g)" \
+        --build-arg USER_ID="$(id -u)" . >/dev/null
 fi
 
-docker run                                    \
-    --mount "type=bind,src=$(pwd)/,dst=/game" \
-    --workdir "/game"                         \
-    "$ZIG_CONTAINER"
+zig_command=$(echo "$*" | sed -e 's/.*\s*--\s\+//g')
+
+echo "$zig_command"
+
+if test -n "$zig_command" ; then
+    docker run                                    \
+        --mount "type=bind,src=$(pwd)/,dst=/game" \
+        --workdir "/game"                         \
+        "$ZIG_CONTAINER" $zig_command
+else
+    docker run                                    \
+        --mount "type=bind,src=$(pwd)/,dst=/game" \
+        --workdir "/game"                         \
+        "$ZIG_CONTAINER"
+fi


### PR DESCRIPTION
Dockerfile is used  to build a simple docker image which includes the Zig toolchain, it can be used to compile the game into WASM within a container. In addition a simple shell script is provided to easily mount the repo as a docker volume and to automatically provide simple means of building the docker image and compiling the project.

When the "build-game.sh" script if provided with no arguments, it builds the image and compiles the project, if the image is already built docker will skip this step. Once an image is built, the project is mounted as a volume and than compiled using 'zig build". To execute a custom command in the container instead of the default, you can pass the '--' argument followed by a command. For example you can run `./build-game.sh -- zig version` to get the version of the Zig toolchain within the container.