### PR TITLE
add logging and initial panic handler

### DIFF
--- a/game/output_wasm_exports.zig
+++ b/game/output_wasm_exports.zig
@@ -36,6 +36,16 @@ pub fn main() !void {
             if (is_line_we_want) {
                 was_line_we_want = true;
             } else if (was_line_we_want) {
+                was_line_we_want = false;
+
+                const decl_start = "pub const ";
+                if (std.mem.startsWith(u8, line, decl_start)) {
+                    const line_at_id = line[decl_start.len..];
+                    const id = line_at_id[0 .. std.mem.indexOf(u8, line_at_id, " ").?];
+                    try PP_file.writer().print("pub const {s} = {s}.{0s};\n", .{id, file_name});
+                    continue;
+                }
+
                 // std.debug.print("Line: {s}\n", .{line});
                 // std.debug.print("Test {any}\n", .{std.mem.indexOf(u8, line, ": u16")});
                 const export_line = try std.fmt.allocPrint(allocator, "{s}{s}{s}", .{"export fn ", file_name, "_"});
@@ -93,7 +103,6 @@ pub fn main() !void {
                 try PP_file.writeAll(");\n");
                 try PP_file.writeAll("}");
                 try PP_file.writeAll("\n");
-                was_line_we_want = false;
             }
         }
         file.close();

--- a/game/wasm.zig
+++ b/game/wasm.zig
@@ -77,6 +77,7 @@ export fn editor_addColumnToWorld(world: u16) void {
     return editor.addColumnToWorld(world);
 }
 const game = @import("game.zig");
+pub const std_options = game.std_options;
 export fn game_loadWorld(index: u16) void {
     return game.loadWorld(index);
 }

--- a/web/scripts/game.js
+++ b/web/scripts/game.js
@@ -1,8 +1,25 @@
 // https://jsdoc.app/about-getting-started
 LOADER.addRequired('wasm');
 
+var global_current_log = "";
+
+function readStr(buffer, ptr, len) {
+    const array = new Uint8Array(buffer, ptr, len);
+    const decoder = new TextDecoder();
+    return decoder.decode(array);
+}
+
 const importObject = {
     imports: _WASM_IMPORTS,
+    env: {
+        console_log_write: function console_log_write(ptr, len) {
+            global_current_log += readStr(_GAME.memory.buffer, ptr, len);
+        },
+        console_log_flush: function() {
+            console.log(global_current_log);
+            global_current_log = "";
+        },
+    }
 };
 WebAssembly.instantiateStreaming(fetch("/wasm/game.wasm"), importObject).then(
     (results) => {


### PR DESCRIPTION
With this change you can write to the javascript console from Zig via std.log, i.e.

```zig
std.log.info("loadWorld index={}", .{index});
```
Would output something like:
```
info: loadWorld index=0
```

With logging, I've added a panic handler.  Currently stack traces don't work but it will log the panic message.