### PR TITLE
fix output_wasm_exports to regenerate when needed

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -9,12 +9,16 @@ pub fn build(b: *Builder) !void {
     const gen_step = b.addRunArtifact(embed_gen);
 
     const wasm_exports = blk: {
-        const gen_wasm_exports_zig_exe = b.addExecutable(.{
+        const gen_exe = b.addExecutable(.{
             .name = "output_wasm_exports",
             .root_source_file = .{ .path = "scripts/output_wasm_exports.zig" },
         });
-        const gen_wasm_exports_zig = b.addRunArtifact(gen_wasm_exports_zig_exe);
-        const wasm_exports_zig = gen_wasm_exports_zig.addOutputFileArg("wasmexports.zig");
+        const gen = b.addRunArtifact(gen_exe);
+        const wasm_exports_zig = gen.addOutputFileArg("wasmexports.zig");
+        inline for (&.{"debug", "diff", "editor", "game", "renderer", "viewport"}) |name| {
+            gen.addFileArg(.{ .path = b.pathFromRoot("game/" ++ name ++ ".zig") });
+        }
+
         break :blk b.createModule(.{
             .source_file = wasm_exports_zig,
         });

--- a/scripts/output_wasm_exports.zig
+++ b/scripts/output_wasm_exports.zig
@@ -7,12 +7,11 @@ var gpa_allocator = std.heap.GeneralPurposeAllocator(.{}){};
 var allocator = gpa_allocator.allocator();
 
 const prefix: []const u8 = "game";
-const files = [_][]const u8{"debug", "diff", "editor", "game", "renderer", "viewport"};
 
 pub fn main() !void {
     const cmdline_args = (try std.process.argsAlloc(allocator))[1..];
-    if (cmdline_args.len != 1) {
-        std.log.err("expected 1 cmdline arg but got {}", .{cmdline_args.len});
+    if (cmdline_args.len < 1) {
+        std.log.err("expected at least 1 cmdline arg", .{});
         std.os.exit(0xff);
     }
     const out_file = cmdline_args[0];
@@ -20,8 +19,9 @@ pub fn main() !void {
     const PP_file = try std.fs.cwd().createFile(out_file, .{ .read = true });
     defer PP_file.close();
 
-    for (files) |file_name| {
-        const full_file = try std.fmt.allocPrint(allocator, "{s}/{s}{s}", .{prefix, file_name, ".zig"});
+    for (cmdline_args[1..]) |full_file| {
+        const base_name = std.fs.path.basename(full_file);
+        const file_name = base_name[0 .. base_name.len - 4];
         var file = try std.fs.cwd().openFile(full_file, .{});
         // defer file.close();
 


### PR DESCRIPTION
Zig's run step caches it's output and will not re-execute if nothing changes.  It uses it's cmdline arguments to calculate the cache, so the solution is to include all the input files on the cmdline.