### PR TITLE
Give Action Write Permission

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v3
     


### PR DESCRIPTION
This makes it so the action has write access to the repo so it can push the build to the release branch.