### PR TITLE
Clamp hidden draggable windows

### DIFF
--- a/web/scripts_js_modules/editor.js
+++ b/web/scripts_js_modules/editor.js
@@ -295,7 +295,7 @@ export class Editor extends HTMLElement {
                 font-size: 1.5em;
             }
             .hidden {
-                display: none !important;
+                visibility: hidden;
             }
             #editor-container {
                 padding: 0.6em;


### PR DESCRIPTION
When adding the style `display: none` on a draggable window it makes it so the window cannot be clamped to the visible area of the screen because its size and position can't be calculated, which can lead to lost windows getting lost out of bounds.

By using `visibility: hidden` instead, it accomplishes the same hidden effect as `display: none` but also allows the correct calculations to take place for the window to be clamped to the visible area. 

> all this for a one line change haha