### PR TITLE
Define custom elements from within their module to avoid defining more than once

### DIFF
--- a/web/scripts_js_modules/cheatsheet.js
+++ b/web/scripts_js_modules/cheatsheet.js
@@ -102,3 +102,4 @@ export class CheatSheet extends HTMLElement {
         `;
     }
 }
+customElements.define('cheatsheet-component', CheatSheet);

--- a/web/scripts_js_modules/collision-entity.js
+++ b/web/scripts_js_modules/collision-entity.js
@@ -18,3 +18,4 @@ export class CollisionEntity extends Entity {
         `;
     }
 }
+customElements.define('collision-entity-component', CollisionEntity);

--- a/web/scripts_js_modules/editor.js
+++ b/web/scripts_js_modules/editor.js
@@ -403,3 +403,4 @@ export class Editor extends HTMLElement {
         }
     }
 }
+customElements.define('editor-component', Editor);

--- a/web/scripts_js_modules/entity.js
+++ b/web/scripts_js_modules/entity.js
@@ -79,3 +79,4 @@ export class Entity extends HTMLElement {
         `;
     }
 }
+customElements.define('entity-component', Entity);

--- a/web/scripts_js_modules/game.js
+++ b/web/scripts_js_modules/game.js
@@ -1,7 +1,7 @@
 import { wasm } from './injector_wasm.js';
-import { Entity } from './entity.js';
-import { CollisionEntity } from './collision-entity.js';
-import { ViewportEntity } from './viewport-entity.js';
+import './entity.js';
+import './collision-entity.js';
+import './viewport-entity.js';
 import '../components/draggable.js';
 
 let current_time_stamp = new Date().getTime();
@@ -98,9 +98,6 @@ window.editorDownload = function (data, file_name) {
     document.body.removeChild(link);
     window.URL.revokeObjectURL(url);
 };
-customElements.define('entity-component', Entity);
-customElements.define('collision-entity-component', CollisionEntity);
-customElements.define('viewport-entity-component', ViewportEntity);
 
 // TODO
 // Multi step
@@ -515,3 +512,4 @@ export class Game extends HTMLElement {
         requestAnimationFrame(tick);
     }
 }
+customElements.define('game-component', Game);

--- a/web/scripts_js_modules/injector.js
+++ b/web/scripts_js_modules/injector.js
@@ -1,16 +1,12 @@
 // TOP LEVEL MODULE
 
 import { Test } from './test.js';
-import { CheatSheet } from './cheatsheet.js';
-import { Game } from './game.js';
+import './cheatsheet.js';
+import './game.js';
+import './editor.js';
 // TODO: Do we actually need an eventbus if we have CustomEvents?
 // Note: game-component might be our top level event bus for global events
 import { EVENTBUS } from './eventbus.js';
-import { Editor } from './editor.js';
-
-customElements.define('cheatsheet-component', CheatSheet);
-customElements.define('game-component', Game);
-customElements.define('editor-component', Editor);
 
 if (!window.requestAnimationFrame)  {
     window.requestAnimationFrame = (function() {

--- a/web/scripts_js_modules/viewport-entity.js
+++ b/web/scripts_js_modules/viewport-entity.js
@@ -31,3 +31,4 @@ export class ViewportEntity extends Entity {
         `;
     }
 }
+customElements.define('viewport-entity-component', ViewportEntity);


### PR DESCRIPTION
This PR makes the modules containing custom elements define them as custom elements instead of making that the job of the dependent module. This avoids errors caused by defining an element multiple times, and makes it easier to use these modules because you don't need to remember to define them yourself outside the module. 